### PR TITLE
빈 문자열을 기본값으로 정의, 데이저 저장시 기본값을 명시적으로 저장

### DIFF
--- a/src/Libplanet.Serialization.Json/DynamicConverters/ModelObjectJsonConverter.cs
+++ b/src/Libplanet.Serialization.Json/DynamicConverters/ModelObjectJsonConverter.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Libplanet.Serialization.Json.DynamicConverters;
 
-internal sealed class ObjectJsonConverter : JsonConverter<object>
+internal sealed class ModelObjectJsonConverter : JsonConverter<object>
 {
     public override bool CanConvert(Type typeToConvert)
         => typeToConvert.IsDefined(typeof(ModelAttribute)) || typeToConvert.IsDefined(typeof(OriginModelAttribute));
@@ -33,13 +33,9 @@ internal sealed class ObjectJsonConverter : JsonConverter<object>
         foreach (var (_, property) in propertyByName)
         {
             var propertyType = property.PropertyType;
-            if (Nullable.GetUnderlyingType(propertyType) is { } underlyingType)
+            if (TypeUtility.TryGetDefault(propertyType, out var defaultValue))
             {
-                property.SetValue(obj, TypeUtility.GetDefault(underlyingType));
-            }
-            else
-            {
-                property.SetValue(obj, TypeUtility.GetDefault(propertyType));
+                property.SetValue(obj, defaultValue);
             }
         }
 
@@ -71,7 +67,7 @@ internal sealed class ObjectJsonConverter : JsonConverter<object>
     {
         var modelOptions = ModelOptionsScope.Current;
         var type = value.GetType();
-        if (modelOptions.IsValidationEnabled && !TypeUtility.IsDefault(value, type))
+        if (modelOptions.IsValidationEnabled && !TypeUtility.IsDefault(value))
         {
             ModelResolver.Validate(value, modelOptions);
         }
@@ -92,7 +88,8 @@ internal sealed class ObjectJsonConverter : JsonConverter<object>
             var propertyType = property.PropertyType;
             var propertyValue = property.GetValue(value);
             var isDefault = TypeUtility.IsDefault(propertyValue);
-            if (isDefault)
+            var emitDefaultValue = modelOptions.EmitDefaultValues || property.EmitDefaultValue;
+            if (isDefault && !emitDefaultValue)
             {
                 continue;
             }

--- a/src/Libplanet.Serialization.Json/Libplanet.Serialization.Json.csproj
+++ b/src/Libplanet.Serialization.Json/Libplanet.Serialization.Json.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <NoWarn>$(NoWarn);SA1012</NoWarn>
+    <DefineConstants>$(DefineConstants);MODEL_JSON</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Libplanet.Serialization.Json/ModelJsonResolver.cs
+++ b/src/Libplanet.Serialization.Json/ModelJsonResolver.cs
@@ -30,7 +30,7 @@ internal static class ModelJsonResolver
     private static readonly JsonConverter[] _dynamicConverters =
     [
         new EnumJsonConverter(),
-        new ObjectJsonConverter(),
+        new ModelObjectJsonConverter(),
         new ScalarValueJsonConverter(),
         new TupleJsonConverter(),
         new KeyValuePairJsonConverter(),

--- a/src/Libplanet.Serialization.Json/ModelOptionsScope.cs
+++ b/src/Libplanet.Serialization.Json/ModelOptionsScope.cs
@@ -1,6 +1,12 @@
-﻿namespace Libplanet.Serialization;
+﻿#if MODEL_JSON
+namespace Libplanet.Serialization.Json;
+#elif MODEL_YAML
+namespace Libplanet.Serialization.Yaml;
+#else
+#error This file must be included in either Libplanet.Serialization.Json or Libplanet.Serialization.Yaml project.
+#endif
 
-public static class ModelOptionsScope
+internal static class ModelOptionsScope
 {
     private static readonly ThreadLocal<Stack<ModelOptions>?> _stack = new();
 

--- a/src/Libplanet.Serialization.Json/ModelTypeScope.cs
+++ b/src/Libplanet.Serialization.Json/ModelTypeScope.cs
@@ -1,0 +1,49 @@
+﻿#if MODEL_JSON
+namespace Libplanet.Serialization.Json;
+#elif MODEL_YAML
+namespace Libplanet.Serialization.Yaml;
+#else
+#error This file must be included in either Libplanet.Serialization.Json or Libplanet.Serialization.Yaml project.
+#endif
+
+internal static class ModelTypeScope
+{
+    private static readonly ThreadLocal<Stack<Type>?> _stack = new();
+
+    public static Type Current => _stack.Value is { Count: > 0 } s ? s.Peek() : typeof(object);
+
+    public static IDisposable Push(Type type)
+    {
+        var s = _stack.Value ??= new Stack<Type>();
+        s.Push(type);
+        return new PopOnDispose(s);
+    }
+
+    public static bool CanOmitTypeInfo(Type type) => CanOmitTypeInfo(type, ModelOptionsScope.Current);
+
+    public static bool CanOmitTypeInfo(Type type, ModelOptions options)
+    {
+        if (options.TypeInfoMode is ModelTypeInfoMode.Always)
+        {
+            return false;
+        }
+
+        if (options.TypeInfoMode is ModelTypeInfoMode.Never)
+        {
+            return true;
+        }
+
+        return Current.IsSealed && type == Current;
+    }
+
+    private sealed class PopOnDispose(Stack<Type> stack) : IDisposable
+    {
+        public void Dispose()
+        {
+            if (stack is { Count: > 0 })
+            {
+                stack.Pop();
+            }
+        }
+    }
+}

--- a/src/Libplanet.Serialization.Json/WrappedJsonConverter.cs
+++ b/src/Libplanet.Serialization.Json/WrappedJsonConverter.cs
@@ -20,7 +20,7 @@ internal sealed class WrappedJsonConverter<T>(JsonConverter<T> innerConverter) :
         var modelType = ModelResolver.GetType(type, version);
 
         reader.ReadPropertyName("value");
-        if (TypeUtility.IsDefaultType(typeToConvert)
+        if (TypeUtility.HasDefaultValue(typeToConvert)
             && reader.TokenType == JsonTokenType.Number
             && reader.TryGetInt32(out var intValue)
             && intValue == 0)

--- a/src/Libplanet.Serialization.Yaml/DynamicConverters/ModelObjectYamlTypeConverter.cs
+++ b/src/Libplanet.Serialization.Yaml/DynamicConverters/ModelObjectYamlTypeConverter.cs
@@ -5,7 +5,7 @@ using YamlDotNet.Serialization;
 
 namespace Libplanet.Serialization.Yaml.DynamicConverters;
 
-internal sealed class ObjectYamlTypeConverter : IYamlTypeConverter
+internal sealed class ModelObjectYamlTypeConverter : IYamlTypeConverter
 {
     public bool Accepts(Type type)
         => type.IsDefined(typeof(ModelAttribute)) || type.IsDefined(typeof(OriginModelAttribute));
@@ -32,13 +32,9 @@ internal sealed class ObjectYamlTypeConverter : IYamlTypeConverter
         foreach (var (_, property) in propertyByName)
         {
             var propertyType = property.PropertyType;
-            if (Nullable.GetUnderlyingType(propertyType) is { } underlyingType)
+            if (TypeUtility.TryGetDefault(propertyType, out var defaultValue))
             {
-                property.SetValue(obj, TypeUtility.GetDefault(underlyingType));
-            }
-            else
-            {
-                property.SetValue(obj, TypeUtility.GetDefault(propertyType));
+                property.SetValue(obj, defaultValue);
             }
         }
 
@@ -71,7 +67,7 @@ internal sealed class ObjectYamlTypeConverter : IYamlTypeConverter
         ArgumentNullException.ThrowIfNull(value);
 
         var modelOptions = ModelOptionsScope.Current;
-        if (modelOptions.IsValidationEnabled && !TypeUtility.IsDefault(value, type))
+        if (modelOptions.IsValidationEnabled && !TypeUtility.IsDefault(value))
         {
             ModelResolver.Validate(value, modelOptions);
         }
@@ -93,7 +89,8 @@ internal sealed class ObjectYamlTypeConverter : IYamlTypeConverter
             var propertyType = property.PropertyType;
             var propertyValue = property.GetValue(value);
             var isDefault = TypeUtility.IsDefault(propertyValue);
-            if (isDefault)
+            var emitDefaultValue = modelOptions.EmitDefaultValues || property.EmitDefaultValue;
+            if (isDefault && !emitDefaultValue)
             {
                 continue;
             }

--- a/src/Libplanet.Serialization.Yaml/DynamicConverters/NullableYamlTypeConverter.cs
+++ b/src/Libplanet.Serialization.Yaml/DynamicConverters/NullableYamlTypeConverter.cs
@@ -10,7 +10,7 @@ internal sealed class NullableYamlTypeConverter : YamlTypeConverter<object>
 
     public override object? Read(IParser parser, Type type, ObjectDeserializer rootDeserializer)
     {
-         if (Nullable.GetUnderlyingType(ModelTypeScope.Current) is not { } underlyingType)
+        if (Nullable.GetUnderlyingType(ModelTypeScope.Current) is not { } underlyingType)
         {
             return rootDeserializer(type);
         }

--- a/src/Libplanet.Serialization.Yaml/Libplanet.Serialization.Yaml.csproj
+++ b/src/Libplanet.Serialization.Yaml/Libplanet.Serialization.Yaml.csproj
@@ -1,11 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);SA1012</NoWarn>
+    <DefineConstants>$(DefineConstants);MODEL_YAML</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Libplanet.Serialization\Libplanet.Serialization.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Libplanet.Serialization.Json\ModelOptionsScope.cs" Link="ModelOptionsScope.cs" />
+    <Compile Include="..\Libplanet.Serialization.Json\ModelTypeScope.cs" Link="ModelTypeScope.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Libplanet.Serialization.Yaml/ModelYamlResolver.cs
+++ b/src/Libplanet.Serialization.Yaml/ModelYamlResolver.cs
@@ -30,7 +30,7 @@ internal static class ModelYamlResolver
     [
         new NullableYamlTypeConverter(),
         new EnumYamlTypeConverter(),
-        new ObjectYamlTypeConverter(),
+        new ModelObjectYamlTypeConverter(),
         new ScalarValueYamlTypeConverter(),
         new TupleYamlTypeConverter(),
         new KeyValuePairYamlTypeConverter(),

--- a/src/Libplanet.Serialization.Yaml/ModelYamlTypeConverter.cs
+++ b/src/Libplanet.Serialization.Yaml/ModelYamlTypeConverter.cs
@@ -44,7 +44,7 @@ public sealed class ModelYamlTypeConverter : IYamlTypeConverter
             }
 
             parser.ReadPropertyName("value");
-            if (TypeUtility.IsDefaultType(modelType)
+            if (TypeUtility.HasDefaultValue(modelType)
                 && parser.Current is YamlDotNet.Core.Events.Scalar { Style: ScalarStyle.Plain, Value: "0" })
             {
                 parser.MoveNext();
@@ -83,13 +83,14 @@ public sealed class ModelYamlTypeConverter : IYamlTypeConverter
             return;
         }
 
+        var modelOptions = ModelOptionsScope.Current;
         var (typeName, version) = ModelResolver.GetTypeInfo(type);
         emitter.WriteStartObject();
         emitter.WriteString("type", typeName);
         emitter.WriteNumber("version", version);
         emitter.WritePropertyName("value");
 
-        if (TypeUtility.IsDefault(value, type))
+        if (TypeUtility.IsDefault(value) && !modelOptions.EmitDefaultValues)
         {
             emitter.WriteNumberValue(0);
         }

--- a/src/Libplanet.Serialization/DataAnnotations/NotDefaultAttribute.cs
+++ b/src/Libplanet.Serialization/DataAnnotations/NotDefaultAttribute.cs
@@ -24,7 +24,7 @@ public sealed class NotDefaultAttribute : ValidationAttribute
                           $"{declaringType.Name}.{memberName} must be a value type.";
             return new ValidationResult(message, [memberName]);
         }
-        else if (TypeUtility.IsDefault(value, valueType))
+        else if (TypeUtility.IsDefault(value))
         {
             var message = $"The value specified in {GetType().Name} on " +
                           $"{declaringType.Name}.{memberName} must not be the default value.";

--- a/src/Libplanet.Serialization/DataAnnotations/NotEmptyAttribute.cs
+++ b/src/Libplanet.Serialization/DataAnnotations/NotEmptyAttribute.cs
@@ -15,7 +15,7 @@ public sealed class NotEmptyAttribute : ValidationAttribute
         if (value is ICollection collection)
         {
             var valueType = value.GetType();
-            if (valueType.IsValueType && IsDefault(value, valueType))
+            if (valueType.IsValueType && IsDefault(value))
             {
                 var message = $"The value specified in {GetType().Name} on " +
                               $"{declaringType.Name}.{memberName} must not be the default value.";
@@ -35,7 +35,7 @@ public sealed class NotEmptyAttribute : ValidationAttribute
         else if (value is IEnumerable enumerable)
         {
             var valueType = value.GetType();
-            if (valueType.IsValueType && IsDefault(value, valueType))
+            if (valueType.IsValueType && IsDefault(value))
             {
                 var message = $"The value specified in {GetType().Name} on " +
                               $"{declaringType.Name}.{memberName} must not be the default value.";

--- a/src/Libplanet.Serialization/DynamicConverters/CollectionModelConverter.cs
+++ b/src/Libplanet.Serialization/DynamicConverters/CollectionModelConverter.cs
@@ -21,12 +21,12 @@ internal abstract class CollectionModelConverter : ModelConverterBase<IEnumerabl
 
         if (type.IsValueType)
         {
-            if (TypeUtility.IsDefault(obj1, type) && TypeUtility.IsDefault(obj2, type))
+            if (TypeUtility.IsDefault(obj1) && TypeUtility.IsDefault(obj2))
             {
                 return true;
             }
 
-            if (TypeUtility.IsDefault(obj1, type) || TypeUtility.IsDefault(obj2, type))
+            if (TypeUtility.IsDefault(obj1) || TypeUtility.IsDefault(obj2))
             {
                 return false;
             }
@@ -58,7 +58,7 @@ internal abstract class CollectionModelConverter : ModelConverterBase<IEnumerabl
 
     public int GetHashCode(object obj, Type type)
     {
-        if (type.IsValueType && TypeUtility.IsDefault(obj, type))
+        if (TypeUtility.IsDefault(obj))
         {
             return 0;
         }

--- a/src/Libplanet.Serialization/DynamicConverters/ModelObjectModelConverter.cs
+++ b/src/Libplanet.Serialization/DynamicConverters/ModelObjectModelConverter.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 
 namespace Libplanet.Serialization.DynamicConverters;
 
-internal sealed class ObjectModelConverter : ModelConverterBase<object>, IModelComparer
+internal sealed class ModelObjectModelConverter : ModelConverterBase<object>, IModelComparer
 {
     public override bool CanConvert(Type type)
         => type.IsDefined(typeof(ModelAttribute)) || type.IsDefined(typeof(OriginModelAttribute));
@@ -75,7 +75,7 @@ internal sealed class ObjectModelConverter : ModelConverterBase<object>, IModelC
     protected override void Write(BinaryWriter writer, object value, ModelOptions options)
     {
         var type = value.GetType();
-        if (options.IsValidationEnabled && !TypeUtility.IsDefault(value, type))
+        if (options.IsValidationEnabled && !TypeUtility.IsDefault(value))
         {
             ModelResolver.Validate(value, options);
         }
@@ -95,7 +95,7 @@ internal sealed class ObjectModelConverter : ModelConverterBase<object>, IModelC
             var propertyType = property.PropertyType;
             var propertyValue = property.GetValue(value);
             var propertyActualType = TypeUtility.GetActualType(propertyValue, propertyType);
-            using var _ = ModelTypeScope.Push(propertyType);
+            using var _ = ModelTypeScope.Push(propertyType, emitDefaultValue: property.EmitDefaultValue);
             ModelSerializer.Serialize(writer, propertyValue, propertyActualType, options);
         }
     }

--- a/src/Libplanet.Serialization/ModelOptions.cs
+++ b/src/Libplanet.Serialization/ModelOptions.cs
@@ -16,5 +16,7 @@ public sealed record class ModelOptions : IServiceProvider
 
     public ModelTypeInfoMode TypeInfoMode { get; init; }
 
+    public bool EmitDefaultValues { get; init; }
+
     public object? GetService(Type serviceType) => _serviceProvider?.GetService(serviceType);
 }

--- a/src/Libplanet.Serialization/ModelProperty.cs
+++ b/src/Libplanet.Serialization/ModelProperty.cs
@@ -13,7 +13,7 @@ public sealed class ModelProperty
         _propertyInfo = propertyInfo;
     }
 
-    public bool ReadOnly => _propertyAttribute.ReadOnly;
+    public bool EmitDefaultValue => _propertyAttribute.EmitDefaultValue;
 
     public Type PropertyType => _propertyInfo.PropertyType;
 

--- a/src/Libplanet.Serialization/ModelResolver.cs
+++ b/src/Libplanet.Serialization/ModelResolver.cs
@@ -31,7 +31,7 @@ public static class ModelResolver
     [
         new NullableModelConverter(),
         new EnumModelConverter(),
-        new ObjectModelConverter(),
+        new ModelObjectModelConverter(),
         new TupleModelConverter(),
         new KeyValuePairModelConverter(),
         new ArrayModelConverter(),

--- a/src/Libplanet.Serialization/ModelSerializer.cs
+++ b/src/Libplanet.Serialization/ModelSerializer.cs
@@ -50,7 +50,7 @@ public static class ModelSerializer
             data.Write(writer);
         }
 
-        if (TypeUtility.IsDefault(value, type))
+        if (TypeUtility.IsDefault(value) && ModelTypeScope.CanWriteDefaultValue(options))
         {
             writer.Write((byte)DataType.Default);
         }
@@ -88,7 +88,7 @@ public static class ModelSerializer
             return null;
         }
 
-        if (ModelTypeScope.CanOmitTypeInfo(type) && dataType == DataType.Header)
+        if (ModelTypeScope.CanOmitTypeInfo(type, options) && dataType == DataType.Header)
         {
             throw new ModelException("Type information is required but not found.");
         }

--- a/src/Libplanet.Serialization/ModelTypeScope.cs
+++ b/src/Libplanet.Serialization/ModelTypeScope.cs
@@ -1,19 +1,19 @@
 ﻿namespace Libplanet.Serialization;
 
-public static class ModelTypeScope
+internal static class ModelTypeScope
 {
-    private static readonly ThreadLocal<Stack<Type>?> _stack = new();
+    private static readonly ThreadLocal<Stack<Properties>?> _stack = new();
 
-    public static Type Current => _stack.Value is { Count: > 0 } s ? s.Peek() : typeof(object);
+    public static Type CurrentType => Current.Type;
 
-    public static IDisposable Push(Type options)
+    public static Properties Current => _stack.Value is { Count: > 0 } s ? s.Peek() : new Properties(typeof(object));
+
+    public static IDisposable Push(Type type, bool emitDefaultValue = false)
     {
-        var s = _stack.Value ??= new Stack<Type>();
-        s.Push(options);
+        var s = _stack.Value ??= new Stack<Properties>();
+        s.Push(new Properties(type, emitDefaultValue));
         return new PopOnDispose(s);
     }
-
-    public static bool CanOmitTypeInfo(Type type) => CanOmitTypeInfo(type, ModelOptionsScope.Current);
 
     public static bool CanOmitTypeInfo(Type type, ModelOptions options)
     {
@@ -27,17 +27,24 @@ public static class ModelTypeScope
             return true;
         }
 
-        return Current.IsSealed && type == Current;
+        return CurrentType.IsSealed && type == CurrentType;
     }
 
-    private sealed class PopOnDispose(Stack<Type> s) : IDisposable
+    public static bool CanWriteDefaultValue(ModelOptions options)
+        => !options.EmitDefaultValues && !Current.EmitDefaultValue;
+
+    private sealed class PopOnDispose(Stack<Properties> stack) : IDisposable
     {
         public void Dispose()
         {
-            if (s is { Count: > 0 })
+            if (stack is { Count: > 0 })
             {
-                s.Pop();
+                stack.Pop();
             }
         }
+    }
+
+    public record class Properties(Type Type, bool EmitDefaultValue = false)
+    {
     }
 }

--- a/src/Libplanet.Serialization/ModelValidationUtility.cs
+++ b/src/Libplanet.Serialization/ModelValidationUtility.cs
@@ -7,7 +7,7 @@ public static class ModelValidationUtility
     public static void Validate(object obj)
     {
         var type = obj.GetType();
-        if (!type.IsValueType || !TypeUtility.IsDefault(obj, type))
+        if (!type.IsValueType || !TypeUtility.IsDefault(obj))
         {
             Validator.ValidateObject(instance: obj, new(obj), true);
         }
@@ -16,7 +16,7 @@ public static class ModelValidationUtility
     public static void Validate(object obj, IDictionary<object, object?> items)
     {
         var type = obj.GetType();
-        if (!type.IsValueType || !TypeUtility.IsDefault(obj, type))
+        if (!type.IsValueType || !TypeUtility.IsDefault(obj))
         {
             Validator.ValidateObject(instance: obj, new(obj, items), true);
         }

--- a/src/Libplanet.Serialization/PropertyAttribute.cs
+++ b/src/Libplanet.Serialization/PropertyAttribute.cs
@@ -5,5 +5,5 @@ public sealed class PropertyAttribute(int index) : Attribute
 {
     public int Index => index;
 
-    public bool ReadOnly { get; set; }
+    public bool EmitDefaultValue { get; init; }
 }

--- a/src/Libplanet.Serialization/TypeUtility.cs
+++ b/src/Libplanet.Serialization/TypeUtility.cs
@@ -153,28 +153,35 @@ public static class TypeUtility
         }
     }
 
-    public static bool IsDefaultType(Type type) => type.IsValueType && !type.IsEnum && !IsNullableType(type);
-
-    public static bool IsDefault(object value, Type type)
+    public static bool HasDefaultValue(Type type)
     {
-        if (IsDefaultType(type))
+        if (type == typeof(string))
         {
-            var defaultValue = _defaultByType.GetOrAdd(type, CreateDefault);
-            return ReferenceEquals(value, defaultValue) || Equals(value, defaultValue);
+            return true;
         }
 
-        return false;
+        if (Nullable.GetUnderlyingType(type) is { } underlyingType)
+        {
+            return HasDefaultValue(underlyingType);
+        }
+
+        return type.IsValueType && !type.IsEnum;
     }
 
-    public static bool IsDefault(object? value) => value is not null && IsDefault(value, value.GetType());
+    public static bool IsDefault(object? value)
+    {
+        if (value is null || !HasDefaultValue(value.GetType()))
+        {
+            return false;
+        }
 
-    public static bool IsKnownType(Type type) => _knownTypes.Contains(type);
-
-    public static bool IsKnownType(string typeName) => _knownTypes.Contains(typeName);
+        var defaultValue = _defaultByType.GetOrAdd(value.GetType(), CreateDefault);
+        return ReferenceEquals(value, defaultValue) || Equals(value, defaultValue);
+    }
 
     public static object GetDefault(Type type)
     {
-        if (type.IsValueType && !IsNullableType(type))
+        if (HasDefaultValue(type))
         {
             return _defaultByType.GetOrAdd(type, CreateDefault);
         }
@@ -183,6 +190,22 @@ public static class TypeUtility
             $"Type '{type.FullName}' is not a value type and does not have a default value.",
             nameof(type));
     }
+
+    public static bool TryGetDefault(Type type, [MaybeNullWhen(false)] out object defaultValue)
+    {
+        if (HasDefaultValue(type))
+        {
+            defaultValue = _defaultByType.GetOrAdd(type, CreateDefault);
+            return true;
+        }
+
+        defaultValue = null;
+        return false;
+    }
+
+    public static bool IsKnownType(Type type) => _knownTypes.Contains(type);
+
+    public static bool IsKnownType(string typeName) => _knownTypes.Contains(typeName);
 
     public static Type GetActualType(object? value, Type type)
     {
@@ -292,7 +315,19 @@ public static class TypeUtility
     }
 
     private static object CreateDefault(Type type)
-        => Activator.CreateInstance(type) ?? throw new UnreachableException("ValueType cannot be null");
+    {
+        if (type == typeof(string))
+        {
+            return string.Empty;
+        }
+
+        if (Nullable.GetUnderlyingType(type) is { } underlyingType)
+        {
+            return CreateDefault(underlyingType);
+        }
+
+        return Activator.CreateInstance(type) ?? throw new UnreachableException("ValueType cannot be null");
+    }
 
     private static string GetTypeNameInternal(Type type)
     {

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.EmitCommitValues.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.EmitCommitValues.cs
@@ -1,0 +1,83 @@
+namespace Libplanet.Serialization.Tests;
+
+public abstract partial class ModelSerializerTestBase<TData>
+{
+    [Fact]
+    public void Model_WithEmitDefaultValuesOptions_SerializeAndDeserialize_Test()
+    {
+        var expectedObject = new EmitDefaultValuesClass();
+        var options = new ModelOptions
+        {
+            EmitDefaultValues = true,
+        };
+        var serialized1 = Serialize(expectedObject, options);
+        var serialized2 = Serialize(expectedObject);
+        Assert.NotEqual(serialized1, serialized2);
+        var actualObject1 = Deserialize<EmitDefaultValuesClass>(serialized1);
+        var actualObject2 = Deserialize<EmitDefaultValuesClass>(serialized2);
+        Assert.Equal(expectedObject, actualObject1);
+        Assert.Equal(expectedObject, actualObject2);
+    }
+
+    [Fact]
+    public void Model_WithEmitDefaultProperty_SerializeAndDeserialize_Test()
+    {
+        var expectedObject = new EmitDefaultPropertyClass();
+        var options = new ModelOptions
+        {
+            EmitDefaultValues = true,
+        };
+        var serialized1 = Serialize(expectedObject, options);
+        var serialized2 = Serialize(expectedObject);
+        Assert.Equal(serialized1, serialized2);
+        var actualObject1 = Deserialize<EmitDefaultPropertyClass>(serialized1);
+        var actualObject2 = Deserialize<EmitDefaultPropertyClass>(serialized2);
+        Assert.Equal(expectedObject, actualObject1);
+        Assert.Equal(expectedObject, actualObject2);
+    }
+
+    [Fact]
+    public void Model_WithEmitDefaultPropertyAndThrow_SerializeAndDeserialize_Test()
+    {
+        var expectedObject = new EmitDefaultThrowClass();
+        var options = new ModelOptions
+        {
+            EmitDefaultValues = true,
+        };
+        Assert.Throws<ModelException>(() => Serialize(expectedObject, options));
+        var serialized2 = Serialize(expectedObject);
+        var actualObject2 = Deserialize<EmitDefaultThrowClass>(serialized2);
+        Assert.Equal(expectedObject, actualObject2);
+    }
+}
+
+[Model("Libplanet_Serialization_Tests_ModelSerializerTest_EmitDefaultValuesClass", Version = 1)]
+public sealed record class EmitDefaultValuesClass : IEquatable<EmitDefaultValuesClass>
+{
+    [Property(0)]
+    public int Value1 { get; init; }
+
+    [Property(1)]
+    public string Value2 { get; init; } = string.Empty;
+}
+
+[Model("Libplanet_Serialization_Tests_ModelSerializerTest_EmitDefaultPropertyClass", Version = 1)]
+public sealed record class EmitDefaultPropertyClass : IEquatable<EmitDefaultPropertyClass>
+{
+    [Property(0, EmitDefaultValue = true)]
+    public int Value1 { get; init; }
+
+    [Property(1, EmitDefaultValue = true)]
+    public string Value2 { get; init; } = string.Empty;
+}
+
+[Model("Libplanet_Serialization_Tests_ModelSerializerTest_EmitDefaultThrowClass", Version = 1)]
+public sealed record class EmitDefaultThrowClass : IEquatable<EmitDefaultThrowClass>
+{
+    [Property(0)]
+    public ImmutableArray<int> Value1 { get; init; }
+
+    public bool Equals(EmitDefaultThrowClass? other) => ModelResolver.Equals(this, other);
+
+    public override int GetHashCode() => ModelResolver.GetHashCode(this);
+}

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.Nullable.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.Nullable.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Libplanet.TestUtilities;
 
 namespace Libplanet.Serialization.Tests;
@@ -13,6 +14,25 @@ public abstract partial class ModelSerializerTestBase<TData>
     {
         var random = new Random(seed);
         var expectedObject = new RecordClassWithNullableProperty(random);
+        var serialized = Serialize(expectedObject);
+        var actualObject = Deserialize<RecordClassWithNullableProperty>(serialized)!;
+        Assert.Equal(expectedObject, actualObject);
+    }
+
+    [Fact]
+    public void NullableProperty_WithDefaultValue_SerializeAndDeserialize_Test()
+    {
+        var expectedObject = new RecordClassWithNullableProperty
+        {
+            Int32 = default(int),
+            Int64 = default(long),
+            Biginteger = default(BigInteger),
+            Enum = default(TestEnum),
+            Boolean = default(bool),
+            String = string.Empty,
+            DateTimeOffset = default(DateTimeOffset),
+            TimeSpan = default(TimeSpan),
+        };
         var serialized = Serialize(expectedObject);
         var actualObject = Deserialize<RecordClassWithNullableProperty>(serialized)!;
         Assert.Equal(expectedObject, actualObject);


### PR DESCRIPTION
## 왜 필요한가

c# 에서 정의하는 기본값과 여기서 정의하는 기본값은 약간 다릅니다. 구조체의 경우 기본 값은 `0` 이며, 클래스의 경우에는 `null` 입니다.

`json` 혹은 `yaml` 에서는 null 을 표현하기 위해서 `null` 이라는 키워드가 제공됩니다. 하지만 기본값에 대해서는 별도의 키워드가 제공되지 않습니다. 아마도 사용자가 어떻게 정의하느냐에 따라서 기본값이 달라지기 때문이 아닌가 추측합니다.

ModelSerializer 에서는 저장되는 모든 구조체에 대해서 기본값을 0으로 간주합니다. 추가로 `string` 의 경우는 클래스이지만 많이 사용되는 데이터이기에 예외적으로 빈 문자열에 대해서 기본값으로 간주합니다. 그리고 기본값은 데이터가 저장될때 특수한 형태로 저장됩니다.

예를들어 

* Binary 에서는 값을 저장하기 전에 타입을 저장하는데 0 은 null, 1 은 기본값, 2는 보통값을 나타냅니다.
* Json 과 Yaml 에서는 Dictionary 일 경우 기본값을 생략하거나 배열일 경우 0 으로 저장합니다.

또 하나의 장점이 있습니다.

```csharp
public struct Point
{
   public int X { get; set; }

   public int Y { get; set; }
}
```

위와 같은 구조체의 경우 기본값일 경우 X 와 Y 둘다 0 이기 때문에 2개의 속성 모두 저장할 필요가 없기에 저장되는 양이 줄어드는 효과가 있습니다.
또한 `ImmutableArray<int>` 처럼 구조체이지만 숫자로 표현되지 못하는 것도 저장을 할 수가 있습니다.

만약에 `json` 이나 `yaml` 을 사용해서 데이터를 시각적으로 표현하기 위한 용도로 사용한다고 했을때 특정 속성의 값이 기본값일 경우는 생략됩니다.
기본값임에도 불구하고 해당 속성이 존재함을 확인하기 위해서 명시적으로 표시해줘야 하는 상황이 발생할 수 있습니다.
예를들어 아래처럼 말이죠.

```json
{
  "currency": "won",
  "value": 0
}
```

그래서 옵션의 `EmitDefaultValues` 나 혹은 `PropertyAttribute.EmityDefaultValue` 를 true 값으로 설정하여 기본값을 명시적으로 표현할 수 있게 할 수 있습니다.

