### PR TITLE
정보 조회용 전용 옵션 추가

### DIFF
--- a/src/Libplanet.Net/Messages/MessageBase.cs
+++ b/src/Libplanet.Net/Messages/MessageBase.cs
@@ -5,5 +5,6 @@ namespace Libplanet.Net.Messages;
 
 public abstract record class MessageBase : IMessage
 {
+    [Property(0, InspectOnly = true)]
     public MessageId Id => new(SHA256.HashData(ModelSerializer.Serialize(this)));
 }

--- a/src/Libplanet.Net/Protocol.cs
+++ b/src/Libplanet.Net/Protocol.cs
@@ -19,6 +19,7 @@ public sealed partial record class Protocol
     [Property(1)]
     public required ImmutableArray<byte> Signature { get; init; }
 
+    [Property(2, InspectOnly = true)]
     public ProtocolHash Hash => new(SHA256.HashData(ModelSerializer.Serialize(this)));
 
     public Address Signer => Metadata.Signer;

--- a/src/Libplanet.Serialization.Json/DynamicConverters/ModelObjectJsonConverter.cs
+++ b/src/Libplanet.Serialization.Json/DynamicConverters/ModelObjectJsonConverter.cs
@@ -26,7 +26,11 @@ internal sealed class ModelObjectJsonConverter : JsonConverter<object>
             var propertyType = property.PropertyType;
             using var _ = ModelTypeScope.Push(propertyType);
             var value = JsonSerializer.Deserialize(ref reader, propertyType, options);
-            property.SetValue(obj, value);
+            if (!property.InspectOnly)
+            {
+                property.SetValue(obj, value);
+            }
+
             propertyByName.Remove(propertyName);
         }
 
@@ -86,6 +90,11 @@ internal sealed class ModelObjectJsonConverter : JsonConverter<object>
         {
             var property = properties[i];
             var propertyType = property.PropertyType;
+            if (property.InspectOnly && modelOptions.Purpose is SerializationPurpose.Contract)
+            {
+                continue;
+            }
+
             var propertyValue = property.GetValue(value);
             var isDefault = TypeUtility.IsDefault(propertyValue);
             var emitDefaultValue = modelOptions.EmitDefaultValues || property.EmitDefaultValue;

--- a/src/Libplanet.Serialization.Json/ModelTypeScope.cs
+++ b/src/Libplanet.Serialization.Json/ModelTypeScope.cs
@@ -23,12 +23,12 @@ internal static class ModelTypeScope
 
     public static bool CanOmitTypeInfo(Type type, ModelOptions options)
     {
-        if (options.TypeInfoMode is ModelTypeInfoMode.Always)
+        if (options.TypeInfoEmission is TypeInfoEmission.Always)
         {
             return false;
         }
 
-        if (options.TypeInfoMode is ModelTypeInfoMode.Never)
+        if (options.TypeInfoEmission is TypeInfoEmission.Never)
         {
             return true;
         }

--- a/src/Libplanet.Serialization.Yaml/DynamicConverters/ModelObjectYamlTypeConverter.cs
+++ b/src/Libplanet.Serialization.Yaml/DynamicConverters/ModelObjectYamlTypeConverter.cs
@@ -25,7 +25,11 @@ internal sealed class ModelObjectYamlTypeConverter : IYamlTypeConverter
             var propertyType = property.PropertyType;
             using var _ = ModelTypeScope.Push(propertyType);
             var propertyValue = rootDeserializer(property.PropertyType);
-            property.SetValue(obj, propertyValue);
+            if (!property.InspectOnly)
+            {
+                property.SetValue(obj, propertyValue);
+            }
+
             propertyByName.Remove(propertyName);
         }
 
@@ -87,6 +91,11 @@ internal sealed class ModelObjectYamlTypeConverter : IYamlTypeConverter
         {
             var property = properties[i];
             var propertyType = property.PropertyType;
+            if (property.InspectOnly && modelOptions.Purpose is SerializationPurpose.Contract)
+            {
+                continue;
+            }
+
             var propertyValue = property.GetValue(value);
             var isDefault = TypeUtility.IsDefault(propertyValue);
             var emitDefaultValue = modelOptions.EmitDefaultValues || property.EmitDefaultValue;

--- a/src/Libplanet.Serialization.Yaml/ModelYamlSerializer.cs
+++ b/src/Libplanet.Serialization.Yaml/ModelYamlSerializer.cs
@@ -15,7 +15,7 @@ public static class ModelYamlSerializer
 
     public static string Serialize<T>(T? obj, ModelOptions options)
         where T : notnull
-        => Serialize(obj, typeof(T), options);
+        => Serialize(obj, obj?.GetType() ?? typeof(T), options);
 
     public static string Serialize(object? obj, Type type) => Serialize(obj, type, ModelOptions.Empty);
 

--- a/src/Libplanet.Serialization/DynamicConverters/ModelObjectModelConverter.cs
+++ b/src/Libplanet.Serialization/DynamicConverters/ModelObjectModelConverter.cs
@@ -47,7 +47,7 @@ internal sealed class ModelObjectModelConverter : ModelConverterBase<object>, IM
             var propertyType = property.PropertyType;
             using var _ = ModelTypeScope.Push(property.PropertyType);
             var propertyValue = ModelSerializer.Deserialize(reader, propertyType, options);
-            property.SetValue(obj, propertyValue);
+            SetPropertyValue(property, obj, propertyValue);
         }
 
         if (type.GetCustomAttribute<OriginModelAttribute>() is { } originModelAttribute)
@@ -93,10 +93,28 @@ internal sealed class ModelObjectModelConverter : ModelConverterBase<object>, IM
         {
             var property = properties[i];
             var propertyType = property.PropertyType;
-            var propertyValue = property.GetValue(value);
+            var propertyValue = GetPropertyValue(property, value, options);
             var propertyActualType = TypeUtility.GetActualType(propertyValue, propertyType);
             using var _ = ModelTypeScope.Push(propertyType, emitDefaultValue: property.EmitDefaultValue);
             ModelSerializer.Serialize(writer, propertyValue, propertyActualType, options);
+        }
+    }
+
+    private static object? GetPropertyValue(ModelProperty property, object obj, ModelOptions options)
+    {
+        if (property.InspectOnly && options.Purpose is SerializationPurpose.Contract)
+        {
+            return null;
+        }
+
+        return property.GetValue(obj);
+    }
+
+    private static void SetPropertyValue(ModelProperty property, object obj, object? value)
+    {
+        if (!property.InspectOnly)
+        {
+            property.SetValue(obj, value);
         }
     }
 }

--- a/src/Libplanet.Serialization/ModelOptions.cs
+++ b/src/Libplanet.Serialization/ModelOptions.cs
@@ -14,7 +14,7 @@ public sealed record class ModelOptions : IServiceProvider
 
     public bool IsValidationEnabled { get; init; }
 
-    public ModelTypeInfoMode TypeInfoMode { get; init; }
+    public TypeInfoEmission TypeInfoEmission { get; init; }
 
     public bool EmitDefaultValues { get; init; }
 

--- a/src/Libplanet.Serialization/ModelOptions.cs
+++ b/src/Libplanet.Serialization/ModelOptions.cs
@@ -14,6 +14,8 @@ public sealed record class ModelOptions : IServiceProvider
 
     public bool IsValidationEnabled { get; init; }
 
+    public SerializationPurpose Purpose { get; init; }
+
     public TypeInfoEmission TypeInfoEmission { get; init; }
 
     public bool EmitDefaultValues { get; init; }

--- a/src/Libplanet.Serialization/ModelProperty.cs
+++ b/src/Libplanet.Serialization/ModelProperty.cs
@@ -15,6 +15,8 @@ public sealed class ModelProperty
 
     public bool EmitDefaultValue => _propertyAttribute.EmitDefaultValue;
 
+    public bool InspectOnly => _propertyAttribute.InspectOnly;
+
     public Type PropertyType => _propertyInfo.PropertyType;
 
     public string Name => _propertyInfo.Name;

--- a/src/Libplanet.Serialization/ModelTypeScope.cs
+++ b/src/Libplanet.Serialization/ModelTypeScope.cs
@@ -17,12 +17,12 @@ internal static class ModelTypeScope
 
     public static bool CanOmitTypeInfo(Type type, ModelOptions options)
     {
-        if (options.TypeInfoMode is ModelTypeInfoMode.Always)
+        if (options.TypeInfoEmission is TypeInfoEmission.Always)
         {
             return false;
         }
 
-        if (options.TypeInfoMode is ModelTypeInfoMode.Never)
+        if (options.TypeInfoEmission is TypeInfoEmission.Never)
         {
             return true;
         }

--- a/src/Libplanet.Serialization/PropertyAttribute.cs
+++ b/src/Libplanet.Serialization/PropertyAttribute.cs
@@ -6,4 +6,6 @@ public sealed class PropertyAttribute(int index) : Attribute
     public int Index => index;
 
     public bool EmitDefaultValue { get; init; }
+
+    public bool InspectOnly { get; init; }
 }

--- a/src/Libplanet.Serialization/SerializationPurpose.cs
+++ b/src/Libplanet.Serialization/SerializationPurpose.cs
@@ -1,0 +1,8 @@
+﻿namespace Libplanet.Serialization;
+
+public enum SerializationPurpose
+{
+    Contract,
+
+    Inspection,
+}

--- a/src/Libplanet.Serialization/TypeInfoEmission.cs
+++ b/src/Libplanet.Serialization/TypeInfoEmission.cs
@@ -1,6 +1,6 @@
 ﻿namespace Libplanet.Serialization;
 
-public enum ModelTypeInfoMode
+public enum TypeInfoEmission
 {
     Auto,
 

--- a/src/Libplanet.Types/Block.cs
+++ b/src/Libplanet.Types/Block.cs
@@ -17,6 +17,7 @@ public sealed partial record class Block
     [NotDefault]
     public required ImmutableArray<byte> Signature { get; init; }
 
+    [Property(3, InspectOnly = true)]
     public BlockHash BlockHash => BlockHash.HashData(ModelSerializer.Serialize(this));
 
     public int Height => Header.Height;

--- a/src/Libplanet.Types/EvidenceBase.cs
+++ b/src/Libplanet.Types/EvidenceBase.cs
@@ -20,6 +20,7 @@ public abstract record class EvidenceBase
     [NotDefault]
     public DateTimeOffset Timestamp { get; init; }
 
+    [Property(3, InspectOnly = true)]
     public EvidenceId Id => new(SHA256.HashData(ModelSerializer.Serialize(this)));
 
     EvidenceId IHasKey<EvidenceId>.Key => Id;

--- a/src/Libplanet.Types/Transaction.cs
+++ b/src/Libplanet.Types/Transaction.cs
@@ -15,6 +15,7 @@ public sealed partial record class Transaction
     [NotDefault]
     public required ImmutableArray<byte> Signature { get; init; }
 
+    [Property(2, InspectOnly = true)]
     public TxId Id => new(SHA256.HashData(ModelSerializer.Serialize(this)));
 
     public long Nonce => Metadata.Nonce;

--- a/test/Libplanet.Net.Tests/Messages/MessageTest.cs
+++ b/test/Libplanet.Net.Tests/Messages/MessageTest.cs
@@ -135,7 +135,7 @@ public sealed class MessageTest(ITestOutputHelper output)
             BlockSummary = genesisBlock,
         };
         Assert.Equal(
-            MessageId.Parse("f7111a9508e986e7c9a8a194882c78db5f3dcc1bf424dca6ffb3826e83a217f9"),
+            MessageId.Parse("3eaa2dc66895f80047216b2eb6c089d1e170918f07a4105c22fa8a6ab664615e"),
             message.Id);
     }
 

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTest.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTest.cs
@@ -22,7 +22,7 @@ public sealed class ModelSerializerTest(ITestOutputHelper output) : ModelSeriali
     [Fact]
     public void DefaultValue_OmitRootTypeInfo_Test()
     {
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         Assert.Equal([1], ModelSerializer.Serialize(0, typeof(int), options));
     }
 

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.Array.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.Array.cs
@@ -34,7 +34,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.Dictionary.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.Dictionary.cs
@@ -34,7 +34,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.HashSet.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.HashSet.cs
@@ -35,7 +35,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableArray.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableArray.cs
@@ -34,7 +34,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableDictionary.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableDictionary.cs
@@ -34,7 +34,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableHashSet.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableHashSet.cs
@@ -35,7 +35,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableList.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableList.cs
@@ -35,7 +35,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableSortedDictionary.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableSortedDictionary.cs
@@ -34,7 +34,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableSortedSet.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ImmutableSortedSet.cs
@@ -34,7 +34,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.InspectOnly.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.InspectOnly.cs
@@ -1,0 +1,49 @@
+namespace Libplanet.Serialization.Tests;
+
+public abstract partial class ModelSerializerTestBase<TData>
+{
+    [Fact]
+    public void Model_InspectOnly_SerializeAndDeserialize_Test()
+    {
+        var expectedObject = new InspectOnlyClass
+        {
+            Value1 = 1,
+            Value2 = 2,
+        };
+        var options = new ModelOptions
+        {
+            Purpose = SerializationPurpose.Inspection,
+        };
+        var serialized = Serialize(expectedObject, options);
+        var actualObject = Deserialize<InspectOnlyClass>(serialized);
+        Assert.NotEqual(expectedObject, actualObject);
+    }
+
+    [Fact]
+    public void Model_InspectOnly_WithoutTypeEmission_SerializeAndDeserialize_Test()
+    {
+        var expectedObject = new InspectOnlyClass
+        {
+            Value1 = 1,
+            Value2 = 2,
+        };
+        var options = new ModelOptions
+        {
+            TypeInfoEmission = TypeInfoEmission.Never,
+            Purpose = SerializationPurpose.Inspection,
+        };
+        var serialized = Serialize(expectedObject, options);
+        var actualObject = Deserialize<InspectOnlyClass>(serialized, options);
+        Assert.NotEqual(expectedObject, actualObject);
+    }
+}
+
+[Model("Libplanet_Serialization_Tests_ModelSerializerTest_InspectOnlyClass", Version = 1)]
+public sealed record class InspectOnlyClass : IEquatable<InspectOnlyClass>
+{
+    [Property(0)]
+    public int Value1 { get; init; }
+
+    [Property(1, InspectOnly = true)]
+    public int Value2 { get; init; }
+}

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.List.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.List.cs
@@ -35,7 +35,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ScalarValue.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.ScalarValue.cs
@@ -42,7 +42,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.SortedDictionary.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.SortedDictionary.cs
@@ -34,7 +34,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.SortedSet.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.SortedSet.cs
@@ -35,7 +35,7 @@ public abstract partial class ModelSerializerTestBase<TData>
             var actualValue1 = Deserialize(serialized1);
             Assert.Equal(expectedValue, actualValue1);
 
-            var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+            var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
             var serialized2 = Serialize(expectedValue, options);
             var actualValue2 = Deserialize(serialized2, property.PropertyType, options);
             Assert.Equal(expectedValue, actualValue2);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.StandardTypes.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.StandardTypes.cs
@@ -72,7 +72,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<BigInteger>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<BigInteger>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -96,7 +96,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<bool>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<bool>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -120,7 +120,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<byte>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<byte>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -144,7 +144,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<char>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<char>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -185,7 +185,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<DateTimeOffset>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<DateTimeOffset>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -209,7 +209,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<Guid>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<Guid>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -233,7 +233,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<int>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<int>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -257,7 +257,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<long>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<long>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -281,7 +281,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<string>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<string>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);
@@ -305,7 +305,7 @@ public abstract partial class ModelSerializerTestBase<TData>
         var actualValue2 = Deserialize<TimeSpan>(serialized2);
         Assert.Equal(expectedValue, actualValue2);
 
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var serialized3 = Serialize(expectedValue, options);
         var actualValue3 = Deserialize<TimeSpan>(serialized3, options);
         Assert.Equal(expectedValue, actualValue3);

--- a/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.Tuple.cs
+++ b/test/Libplanet.Serialization.Tests/ModelSerializerTestBase.Tuple.cs
@@ -27,7 +27,7 @@ public abstract partial class ModelSerializerTestBase<TData>
     public void TupleProperty_WithNoTypeInfo_SerializeAndDeserialize_Test(int seed)
     {
         var random = new Random(seed);
-        var options = new ModelOptions { TypeInfoMode = ModelTypeInfoMode.Never };
+        var options = new ModelOptions { TypeInfoEmission = TypeInfoEmission.Never };
         var expectedObject = new RecordClassWithTuple(random);
         var serialized = Serialize(expectedObject, options);
         var actualObject = Deserialize<RecordClassWithTuple>(serialized, options)!;

--- a/test/Libplanet.TestUtilities/Actions/DumbAction.cs
+++ b/test/Libplanet.TestUtilities/Actions/DumbAction.cs
@@ -58,7 +58,6 @@ public sealed record class DumbAction : ActionBase, IEquatable<DumbAction>
         {
             var items = world.GetValueOrDefaultLenient(AccountAddress, append.At, string.Empty);
             world[AccountAddress, append.At] = items == string.Empty ? append.Item : $"{items},{append.Item}";
-            Trace.WriteLine(world[AccountAddress, append.At]);
         }
 
         if (Transfer is { } transfer)

--- a/test/Libplanet.Tests/Action/BlockExecutorTest.cs
+++ b/test/Libplanet.Tests/Action/BlockExecutorTest.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Libplanet.Builtin;
 using Libplanet.Data;
 using Libplanet.Extensions;
@@ -475,15 +476,19 @@ public partial class BlockExecutorTest(ITestOutputHelper output)
            [.. blockTxs2],
            blockExecution2.Executions.Select(item => item.Transaction));
         Assert.Equal(3, actionExecutions2.Length);
-        Assert.Equal(
-            ["A", "B", "C", null, "F"],
-            addresses.Select(item => actionExecutions2[0].LeaveWorld.GetValueOrDefault(SystemAccount, item)));
-        Assert.Equal(
-            ["A,D", "B", "C", null, "F"],
-            addresses.Select(item => actionExecutions2[1].LeaveWorld.GetValueOrDefault(SystemAccount, item)));
-        Assert.Equal(
-            ["A,D", "B", "C", "E", "F"],
-            addresses.Select(item => actionExecutions2[2].LeaveWorld.GetValueOrDefault(SystemAccount, item)));
+
+        var values1 = addresses.Select(item => actionExecutions2[0].LeaveWorld.GetSystemValueOrDefault(item));
+        var values2 = addresses.Select(item => actionExecutions2[1].LeaveWorld.GetSystemValueOrDefault(item));
+        var values3 = addresses.Select(item => actionExecutions2[2].LeaveWorld.GetSystemValueOrDefault(item));
+#if DEBUG
+        TraceArray(values1);
+        TraceArray(values2);
+        TraceArray(values3);
+#endif // DEBUG
+
+        Assert.Equal(["A,D", "B", "C", null, null], values1);
+        Assert.Equal(["A,D", "B", "C", null, "F"], values2);
+        Assert.Equal(["A,D", "B", "C", "E", "F"], values3);
 
         Assert.Equal("A,D", blockExecution2.LeaveWorld.GetSystemValue(addresses[0]));
         Assert.Equal("B", blockExecution2.LeaveWorld.GetSystemValue(addresses[1]));
@@ -605,4 +610,12 @@ public partial class BlockExecutorTest(ITestOutputHelper output)
         var blockExecution = blockExecutor.Execute(block);
         Assert.Equal(new World(repository.States, blockExecution.LeaveWorld.Hash), blockExecution.LeaveWorld);
     }
+
+#if DEBUG
+    private static void TraceArray(IEnumerable array)
+    {
+        var items = array.Cast<object>().Select(item => item is null ? "null" : $"\"{item}\"");
+        System.Diagnostics.Trace.WriteLine($"[{string.Join(", ", items)}]");
+    }
+#endif // DEBUG
 }


### PR DESCRIPTION
## 왜 필요한가

일반적으로 Serialization 기능은 Deserialization 을 하기 위해 존재합니다. Serialization 과 Deserialization 는 서로에 대해서 불가결한 요소입니다. 따라서 모든 데이터가 Serialization 된다면 반드시 Deserialization 이 되야 하는 전제가 있습니다.

단순히 데이터를 조회하기 위해서 나열한다는 입장에서 본다면 이는 Serialization 이 아니라 Format 과 같은 다른 언어를 사용해야 합니다. 이런 기능을 만들기 위해서 따로 만드는 일은 비효율적입니다. 그래서 Serialization 에 약간의 개념을 섞어서 데이터 조회를 위한 기능을 추가하였습니다.

## 사용법

우선 정의는 아래와 같습니다.

```csharp
class Model
{
    [Property(0, InspectOnly = true)]
    public int Value { get; init; }
}
```

이렇게 정의된 속성은 Serialization 시에 값이 출력되지 않습니다.
Binary 같은 경우 `null` 로 간주되며, json 이나 yaml 경우에는 생략됩니다.

InspectOnly 속성의 값을 출력하기 위해서는 ModelOptions 의 Purpose 속성을 사용해야 합니다.
기본값은 `Contract` 이고 InspectOnly 속성의 값을 출력하기 위해서는 `Inspection` 을 사용합니다.

`Inspection` 를 사용할때 알아두어야 할 사항이 있습니다. 출력된 데이터가 Deserialization 이 된다고 하더래도 원래 객체와 동일하다는 보장이 없습니다.
왜냐하면 Deserialization 시에 출력된 데이터에 값이 존재한다고 하더라도 InspectOnly 가 true 인 속성은 SetValue 작업을 하지 않기 때문입니다.

